### PR TITLE
Fix an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ follows:
               reverse
               $ map fst
               $ sortBy (comparing snd)
-              $ either error id $ f $ ColumnIndex 1
+              $ either error id $ f (ColumnIndex 1) Nothing
          }
 ```
 


### PR DESCRIPTION
Function argument of `selectBenchmarks` was not provided enough arguments.